### PR TITLE
Proper A7105 sleep from MPM

### DIFF
--- a/A7105_SPI.cpp
+++ b/A7105_SPI.cpp
@@ -226,8 +226,8 @@ static void __attribute__((unused)) A7105_SetVCOBand(uint8_t vb1, uint8_t vb2)
 
 
 void A7105_Sleep(void) {
-	A7105_SetTxRxMode(TXRX_OFF);
-    A7105_Strobe(A7105_SLEEP);
+	A7105_WriteReg(A7105_0B_GPIO1_PIN1, 0x33);
+	A7105_WriteReg(A7105_0C_GPIO2_PIN_II, 0x33);
 }
 
 //#define ID_NORMAL 0x55201041


### PR DESCRIPTION
This was tested few years ago on Flysky i6x in OpenI6X project to properly put A7105 into sleep, measured using multi meter.

Solution is taken from Multiprotocol Module sources.